### PR TITLE
Add ability to include an existing OpenStack credentials file

### DIFF
--- a/helm/cluster-openstack/Chart.yaml
+++ b/helm/cluster-openstack/Chart.yaml
@@ -3,7 +3,7 @@ name: cluster-openstack
 description: A helm chart for creating Cluster API clusters with the OpenStack infrastructure provider (CAPO).
 home: https://github.com/eschercloudai/cluster-openstack
 type: application
-version: 0.5.0
+version: 0.6.0
 restrictions:
   compatibleProviders:
     - openstack

--- a/helm/cluster-openstack/templates/_helpers.tpl
+++ b/helm/cluster-openstack/templates/_helpers.tpl
@@ -112,8 +112,27 @@ using only the parameters used in openstack_machine_template.yaml.
 {{- end }}
 {{- end -}}
 
-
 {{- define "osmtRevisionOfControlPlane" -}}
 {{- $outerScope := . }}
 {{- include "osmtRevision" (set (merge $outerScope .Values.controlPlane) "name" "control-plane") }}
+{{- end -}}
+
+{{/*
+Create a name for a cluster component.
+*/}}
+{{- define "openstack-cluster.componentName" -}}
+{{- $ctx := index . 0 -}}
+{{- $componentName := index . 1 -}}
+{{- printf "%s-%s" $ctx.Release.Name $componentName | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Name of the secret containing the cloud credentials.
+*/}}
+{{- define "cluster-openstack.cloudCredentialsSecretName" -}}
+{{- if .Values.cloudConfig -}}
+{{- .Values.cloudConfig -}}
+{{- else -}}
+{{ include "openstack-cluster.componentName" (list . "cloud-credentials") -}}
+{{- end -}}
 {{- end -}}

--- a/helm/cluster-openstack/templates/openstack_cluster.yaml
+++ b/helm/cluster-openstack/templates/openstack_cluster.yaml
@@ -14,7 +14,7 @@ spec:
   {{- end }}
   {{- end }}
   identityRef:
-    name: {{ .Values.cloudConfig }}
+    name: {{ include "cluster-openstack.cloudCredentialsSecretName" . }}
     kind: Secret
   apiServerLoadBalancer:
     enabled: true

--- a/helm/cluster-openstack/templates/openstack_machine_template.yaml
+++ b/helm/cluster-openstack/templates/openstack_machine_template.yaml
@@ -13,7 +13,7 @@ spec:
       cloudName: {{ $.Values.cloudName | quote }}
       flavor: {{ .flavor | quote }}
       identityRef:
-        name: {{ $.Values.cloudConfig }}
+        name: {{ include "cluster-openstack.cloudCredentialsSecretName" . }}
         kind: Secret
       {{- if not $.Values.nodeCIDR }}
       networks:

--- a/helm/cluster-openstack/templates/secret-cloud-config.yaml
+++ b/helm/cluster-openstack/templates/secret-cloud-config.yaml
@@ -1,0 +1,23 @@
+{{- if not .Values.cloudConfig }}
+{{- $cloud := index .Values.clouds .Values.cloudName }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "cluster-openstack.cloudCredentialsSecretName" . }}
+  labels: {{ include "labels.common" $ | nindent 4 }}
+  # If the cloud credentials are deleted before the cluster has finished deleting, then the cluster
+  # deletion cannot proceed any further. So prevent Helm from deleting it.
+  annotations:
+    "helm.sh/resource-policy": keep
+stringData:
+  # Just include the data for the cloud we will be using
+  clouds.yaml: |
+    clouds:
+      {{ .Values.cloudName | default "openstack" }}:
+        {{ index .Values.clouds .Values.cloudName | toYaml | indent 8 | trim }}
+  {{- with .Values.cloudCACert }}
+  cacert: |
+    {{ . | indent 4 | trim }}
+  {{- end }}
+{{- end }}

--- a/helm/cluster-openstack/values.yaml
+++ b/helm/cluster-openstack/values.yaml
@@ -2,7 +2,11 @@ apiServer:
   enableAdmissionPlugins: "NamespaceLifecycle,LimitRanger,ServiceAccount,ResourceQuota,PersistentVolumeClaimResize,DefaultStorageClass,Priority,DefaultTolerationSeconds,MutatingAdmissionWebhook,ValidatingAdmissionWebhook"
   featureGates: "TTLAfterFinished=true"
 baseDomain: ""  # Customer base domain
+
+clouds: # Content for the clouds.yaml file
+# OR
 cloudConfig: ""  # Name of existing cloud-config secret in management cluster namespace.
+
 cloudName: ""  # Name of cloud in cloud-config secret "cloud.yaml" value.
 cloudCACert: "" # PEM-encoded CA certificate for target OpenStack API
 clusterDescription: ""  # Cluster description used in metadata.


### PR DESCRIPTION
Simplify the number of steps required to provision a cluster by making the Secret creation for the OpenStack cloud credentials optional. Instead, a user can simply specify that file as another set of values to Helm and it'll be appropriately picked up and automatically turned into a Secret that CAPO then uses.

This feature was copied from StackHPC's Helm chart, see [their repo](https://github.com/stackhpc/capi-helm-charts/tree/main/charts/openstack-cluster#openstack-credentials) for further details.