### PR TITLE
Add ability to specify node labels as well as additional FQDNs for the API

### DIFF
--- a/helm/cluster-openstack/Chart.yaml
+++ b/helm/cluster-openstack/Chart.yaml
@@ -3,7 +3,7 @@ name: cluster-openstack
 description: A helm chart for creating Cluster API clusters with the OpenStack infrastructure provider (CAPO).
 home: https://github.com/eschercloudai/cluster-openstack
 type: application
-version: 0.6.0
+version: 0.6.1
 restrictions:
   compatibleProviders:
     - openstack

--- a/helm/cluster-openstack/templates/kubeadm_config_template.yaml
+++ b/helm/cluster-openstack/templates/kubeadm_config_template.yaml
@@ -14,6 +14,11 @@ spec:
         nodeRegistration:
           kubeletExtraArgs:
             {{- include "kubeletExtraArgs" . | nindent  12}}
-            node-labels: "eschercloud.ai/node-pool={{ .name }}"
+            node-labels:
+              {{- if .nodeLabels }} 
+              "eschercloud.ai/node-pool={{ .name }}{{- range $k, $v := .nodeLabels }},{{ $k }}={{ $v }}{{- end }}"
+              {{- else }}
+              "eschercloud.ai/node-pool={{ .name }}"
+              {{- end }}
           name: {{ include "nodeName" . }}
 {{- end }}

--- a/helm/cluster-openstack/templates/kubeadm_control_plane.yaml
+++ b/helm/cluster-openstack/templates/kubeadm_control_plane.yaml
@@ -9,6 +9,14 @@ spec:
   kubeadmConfigSpec:
     clusterConfiguration:
       apiServer:
+        certSANs:
+          - 127.0.0.1
+          - localhost
+          {{- if .Values.apiServer.certSANs }}
+          {{- range $v := .Values.apiServer.certSANs }}
+          - {{ $v }}
+          {{- end }}
+          {{- end }}
         extraArgs:
           cloud-provider: external
           enable-admission-plugins: {{ .Values.apiServer.enableAdmissionPlugins }}


### PR DESCRIPTION
Let users automatically labels nodes in a given node pool, and also include the ability to pass in a list of additional FQDNs that are added to the API server's x509 certificate.