### PR TITLE
patch: adding support for flatcar

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,6 @@
 # This is a basic workflow to help you get started with Actions
 
-name: Relese and publish Helm Chart
+name: Release and publish Helm Chart
 
 # Controls when the workflow will run
 on:

--- a/helm/cluster-openstack/Chart.yaml
+++ b/helm/cluster-openstack/Chart.yaml
@@ -4,7 +4,7 @@ name: cluster-openstack
 description: A helm chart for creating Cluster API clusters with the OpenStack infrastructure provider (CAPO).
 home: https://github.com/eschercloudai/cluster-openstack
 type: application
-version: 0.6.10
+version: 0.6.11
 restrictions:
   compatibleProviders:
     - openstack

--- a/helm/cluster-openstack/templates/_helpers.tpl
+++ b/helm/cluster-openstack/templates/_helpers.tpl
@@ -68,8 +68,21 @@ room for such suffix.
 {{- end -}}
 
 {{- define "nodeName" -}}
+{{- if .Values.ignition.enable -}}
+__REPLACE_NODE_NAME__
+{{- else -}}
 '{{ `{{ local_hostname }}` }}'
 {{- end -}}
+{{- end -}}
+
+# In Flatcar kubeadm configuration is in different directory because /run
+# can't be provisioned with ignition.
+{{- define "nodeNameReplacePreKubeadmCommands" -}}
+{{- if .Values.ignition.enable }}
+- bash -c "sed -i 's/__REPLACE_NODE_NAME__/$(hostname -s)/g' /etc/kubeadm.yml"
+{{- end }}
+{{- end -}}
+
 
 {{/*
 Updates in KubeadmConfigTemplate will not trigger any rollout for worker nodes.

--- a/helm/cluster-openstack/templates/kubeadm_config_template.yaml
+++ b/helm/cluster-openstack/templates/kubeadm_config_template.yaml
@@ -14,8 +14,9 @@ spec:
       files:
       {{- .files | nindent 8 }}
       {{- end }}
-      {{- if .preKubeadmCommands }}
       preKubeadmCommands:
+      {{- include "nodeNameReplacePreKubeadmCommands" . | nindent 8 }}
+      {{- if .preKubeadmCommands }}
       {{- .preKubeadmCommands | nindent 8 }}
       {{- end }}
       {{- if .postKubeadmCommands }}
@@ -27,10 +28,26 @@ spec:
           kubeletExtraArgs:
             {{- include "kubeletExtraArgs" . | nindent  12}}
             node-labels:
-              {{- if .nodeLabels }} 
+              {{- if .nodeLabels }}
               "eschercloud.ai/node-pool={{ .name }}{{- range $k, $v := .nodeLabels }},{{ $k }}={{ $v }}{{- end }}"
               {{- else }}
               "eschercloud.ai/node-pool={{ .name }}"
               {{- end }}
           name: {{ include "nodeName" . }}
+      {{ if .Values.ignition.enable }}
+      format: ignition
+      ignition:
+        containerLinuxConfig:
+          additionalConfig: |
+            systemd:
+              units:
+              - name: kubeadm.service
+                enabled: true
+                dropins:
+                - name: 10-flatcar.conf
+                  contents: |
+                    [Unit]
+                    Requires=containerd.service
+                    After=containerd.service
+      {{ end }}
 {{- end }}

--- a/helm/cluster-openstack/templates/kubeadm_control_plane.yaml
+++ b/helm/cluster-openstack/templates/kubeadm_control_plane.yaml
@@ -54,11 +54,34 @@ spec:
         kubeletExtraArgs:
           {{- include "kubeletExtraArgs" . | nindent  10}}
         name: {{ include "nodeName" . }}
+    {{- if not .Values.ignition.enable }}
     useExperimentalRetryJoin: true
+    {{- end }}
     files:
       {{- include "kubeProxyFiles" . | nindent 6 }}
     preKubeadmCommands:
+      {{- include "nodeNameReplacePreKubeadmCommands" . | nindent 6 }}
       {{- include "kubeProxyPreKubeadmCommands" . | nindent 6 }}
+    {{- if .Values.ignition.enable }}
+    format: ignition
+    ignition:
+      containerLinuxConfig:
+        additionalConfig: |
+          systemd:
+            units:
+            - name: coreos-metadata-sshkeys@.service
+              enabled: true
+            - name: kubeadm.service
+              enabled: true
+              dropins:
+              - name: 10-flatcar.conf
+                contents: |
+                  [Unit]
+                  Requires=containerd.service coreos-metadata.service
+                  After=containerd.service coreos-metadata.service
+                  [Service]
+                  EnvironmentFile=/run/metadata/flatcar
+    {{- end }}
   machineTemplate:
     infrastructureRef:
       apiVersion: {{ include "infrastructureApiVersion" . }}

--- a/helm/cluster-openstack/values.schema.json
+++ b/helm/cluster-openstack/values.schema.json
@@ -96,6 +96,17 @@
         "externalNetworkID": {
             "type": "string"
         },
+        "ignition": {
+            "type": "object",
+            "properties": {
+                "enable": {
+                    "type": "boolean"
+                }
+            },
+            "required": [
+                "enable"
+            ]
+        },
         "kubernetesVersion": {
             "type": "string"
         },

--- a/helm/cluster-openstack/values.yaml
+++ b/helm/cluster-openstack/values.yaml
@@ -54,6 +54,9 @@ kubernetesVersion: ""  # Version of Kubernetes. If machine images are specified,
 managementCluster: ""  # Name of cluster which owns this workload cluster.
 organization: ""  # Organization which owns the cluster.
 
+ignition:
+  enable: true # For flatcar support.
+
 nodeCIDR: ""  # The OpenStack Subnet to be created.
 externalNetworkID: ""  # UUID of external network (optional unless there are multiple external networks).
 networkName: ""  # Existing network name. Ignored when nodeCIDR is set.


### PR DESCRIPTION
This adds a few extra bits for Flatcar.

Note that the **Alpha** feature gate for ignition bootstrap needs enabling for this:
https://cluster-api.sigs.k8s.io/tasks/experimental-features/ignition.html

As a result, this needs discussion on how much we rely on this. I see no reason why this wouldn't be promoted considering it's one of the only way I've found so far to pass in the ignition configuration for Flatcar.

